### PR TITLE
Add node feature path support

### DIFF
--- a/lib/data/datamodule/spatiotemporal.py
+++ b/lib/data/datamodule/spatiotemporal.py
@@ -1,5 +1,7 @@
 import sys
 import warnings
+import numpy as np
+import pandas as pd
 import pytorch_lightning as pl
 from torch.utils.data import DataLoader, Subset, RandomSampler
 
@@ -130,6 +132,20 @@ class SpatioTemporalDataModule(pl.LightningDataModule):
                           batch_size=batch_size,
                           num_workers=self.workers,
                           **kwargs)
+
+    @staticmethod
+    def load_node_feats(path):
+        """Load node features from ``path``.
+
+        Accepts ``.npy`` or ``.csv`` files and returns a numpy array.
+        """
+        if path is None:
+            return None
+        if path.endswith('.npy') or path.endswith('.npz'):
+            return np.load(path)
+        if path.endswith('.csv'):
+            return pd.read_csv(path, header=None).values
+        raise ValueError(f'Unsupported node feature format for {path}')
 
     def train_dataloader(self, shuffle=True, batch_size=None):
         if self.samples_per_epoch is not None:

--- a/train.py
+++ b/train.py
@@ -67,6 +67,7 @@ def parse_args():
     parser.add_argument('--seed', type=int, default=1)
     parser.add_argument("--model-name", type=str, default='kits')
     parser.add_argument("--dataset-name", type=str, default='la_point')
+    parser.add_argument("--node-feat-path", type=str, default=None)
     parser.add_argument("--miss-rate", default=0.5, type=float)
     parser.add_argument("--mode", default="road", choices=["road"], type=str)
     parser.add_argument("--test-entries", default="", choices=["", "metr_la_coarse_to_fine.txt", "metr_la_coarse_to_fine_hard.txt", "metr_la_region.txt", "metr_la_region_hard.txt"], type=str)
@@ -136,11 +137,14 @@ def run_experiment(args):
     ########################################
     # instantiate dataset
     dataset_cls = GraphImputationDataset if has_graph_support(model_cls) else ImputationDataset
+    node_feats = SpatioTemporalDataModule.load_node_feats(args.node_feat_path)
+    exo = {'node_feats': node_feats} if node_feats is not None else None
     torch_dataset = dataset_cls(*dataset.numpy(return_idx=True),
                                 mask=dataset.training_mask,
                                 eval_mask=dataset.eval_mask,
                                 window=args.window,
-                                stride=args.stride)
+                                stride=args.stride,
+                                exogenous=exo)
 
     # get train/val/test indices
     split_conf = parser_utils.filter_function_args(args, dataset.splitter, return_dict=True)


### PR DESCRIPTION
## Summary
- allow specifying node feature data with `--node-feat-path`
- load node features when creating `GraphImputationDataset`
- add helper `SpatioTemporalDataModule.load_node_feats`

## Testing
- `python -m py_compile train.py lib/data/datamodule/spatiotemporal.py`

------
https://chatgpt.com/codex/tasks/task_e_684fe69de044832a9c101a3c8d83ead2