### PR TITLE
Fix node feats replication in datamodule

### DIFF
--- a/lib/data/datamodule/spatiotemporal.py
+++ b/lib/data/datamodule/spatiotemporal.py
@@ -145,7 +145,8 @@ class SpatioTemporalDataModule(pl.LightningDataModule):
                 raise ValueError(f'node features shape mismatch: expected {self.torch_dataset.n_nodes} nodes, got {node_feats.shape}')
             self.node_feats = node_feats
             if hasattr(self.torch_dataset, 'node_feats'):
-                self.torch_dataset.node_feats = node_feats
+                repeated = np.repeat(node_feats[None, ...], self.torch_dataset.n_steps, axis=0)
+                self.torch_dataset.node_feats = repeated
 
     def _data_loader(self, dataset, shuffle=False, batch_size=None, **kwargs):
         batch_size = self.batch_size if batch_size is None else batch_size


### PR DESCRIPTION
## Summary
- keep `self.node_feats` 2-D but replicate to dataset length when storing in dataset

## Testing
- `python -m py_compile lib/data/datamodule/spatiotemporal.py`

------
https://chatgpt.com/codex/tasks/task_e_6850064304ec832ab66b7b155b0ea7a5